### PR TITLE
ARXIVCE-4313: update copyright notice to arXiv, Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) arXiv, Inc.
+Copyright (c) 2026 arXiv, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 arXiv
+Copyright (c) arXiv, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
⚠️ **DO NOT MERGE without checking with Jake Weiskoff (jake@arxiv.org) first.**
The copyright holder/year wording for ARXIVCE-4313 is not finalized. This PR is review-ready but must not be merged until Jake gives the go-ahead.

Part of the arXiv spinout from Cornell (ARXIVCE-4313). Updates the LICENSE copyright holder to `arXiv, Inc.` and drops the year, per direction to normalize all repos org-wide.